### PR TITLE
Add plugin that expands order address with region fk

### DIFF
--- a/src/FondOfSpryker/Zed/SalesRegionConnector/Business/Expander/OrderAddressExpander.php
+++ b/src/FondOfSpryker/Zed/SalesRegionConnector/Business/Expander/OrderAddressExpander.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace FondOfSpryker\Zed\SalesRegionConnector\Business\Expander;
+
+use FondOfSpryker\Zed\SalesRegionConnector\Dependency\Facade\SalesRegionConnectorToCountryFacadeInterface;
+use Generated\Shared\Transfer\AddressTransfer;
+
+class OrderAddressExpander
+{
+    /**
+     * @var \FondOfSpryker\Zed\Country\Business\CountryFacade
+     */
+    private $countryFacade;
+
+    /**
+     * @param \FondOfSpryker\Zed\SalesRegionConnector\Dependency\Facade\SalesRegionConnectorToCountryFacadeInterface $countryFacade
+     */
+    public function __construct(SalesRegionConnectorToCountryFacadeInterface $countryFacade)
+    {
+        $this->countryFacade = $countryFacade;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\AddressTransfer $addressTransfer
+     *
+     * @return \Generated\Shared\Transfer\AddressTransfer
+     */
+    public function expandWithRegion(AddressTransfer $addressTransfer): AddressTransfer
+    {
+        $regionIso2Code = $addressTransfer->getRegion();
+
+        if ($regionIso2Code === null || $addressTransfer->getFkRegion() !== null) {
+            return $addressTransfer;
+        }
+
+        $fkRegion = $this->countryFacade->getIdRegionByIso2Code($regionIso2Code);
+
+        return $addressTransfer->setFkRegion($fkRegion);
+    }
+}

--- a/src/FondOfSpryker/Zed/SalesRegionConnector/Business/Expander/OrderAddressExpander.php
+++ b/src/FondOfSpryker/Zed/SalesRegionConnector/Business/Expander/OrderAddressExpander.php
@@ -5,12 +5,12 @@ namespace FondOfSpryker\Zed\SalesRegionConnector\Business\Expander;
 use FondOfSpryker\Zed\SalesRegionConnector\Dependency\Facade\SalesRegionConnectorToCountryFacadeInterface;
 use Generated\Shared\Transfer\AddressTransfer;
 
-class OrderAddressExpander
+class OrderAddressExpander implements OrderAddressExpanderInterface
 {
     /**
-     * @var \FondOfSpryker\Zed\Country\Business\CountryFacade
+     * @var \FondOfSpryker\Zed\SalesRegionConnector\Dependency\Facade\SalesRegionConnectorToCountryFacadeInterface
      */
-    private $countryFacade;
+    protected $countryFacade;
 
     /**
      * @param \FondOfSpryker\Zed\SalesRegionConnector\Dependency\Facade\SalesRegionConnectorToCountryFacadeInterface $countryFacade

--- a/src/FondOfSpryker/Zed/SalesRegionConnector/Business/Expander/OrderAddressExpanderInterface.php
+++ b/src/FondOfSpryker/Zed/SalesRegionConnector/Business/Expander/OrderAddressExpanderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace FondOfSpryker\Zed\SalesRegionConnector\Business\Expander;
+
+use Generated\Shared\Transfer\AddressTransfer;
+
+interface OrderAddressExpanderInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\AddressTransfer $addressTransfer
+     *
+     * @return \Generated\Shared\Transfer\AddressTransfer
+     */
+    public function expandWithRegion(AddressTransfer $addressTransfer): AddressTransfer;
+}

--- a/src/FondOfSpryker/Zed/SalesRegionConnector/Business/SalesRegionConnectorBusinessFactory.php
+++ b/src/FondOfSpryker/Zed/SalesRegionConnector/Business/SalesRegionConnectorBusinessFactory.php
@@ -2,6 +2,7 @@
 
 namespace FondOfSpryker\Zed\SalesRegionConnector\Business;
 
+use FondOfSpryker\Zed\SalesRegionConnector\Business\Expander\OrderAddressExpander;
 use FondOfSpryker\Zed\SalesRegionConnector\Business\Model\SalesOrderAddressHydrator;
 use FondOfSpryker\Zed\SalesRegionConnector\Business\Model\SalesOrderAddressHydratorInterface;
 use FondOfSpryker\Zed\SalesRegionConnector\Dependency\Facade\SalesRegionConnectorToCountryFacadeInterface;
@@ -16,6 +17,11 @@ class SalesRegionConnectorBusinessFactory extends AbstractBusinessFactory
     public function createSalesOrderAddressHydrator(): SalesOrderAddressHydratorInterface
     {
         return new SalesOrderAddressHydrator($this->getCountryFacade());
+    }
+
+    public function createOrderAddressExpander()
+    {
+        return new OrderAddressExpander($this->getCountryFacade());
     }
 
     /**

--- a/src/FondOfSpryker/Zed/SalesRegionConnector/Business/SalesRegionConnectorBusinessFactory.php
+++ b/src/FondOfSpryker/Zed/SalesRegionConnector/Business/SalesRegionConnectorBusinessFactory.php
@@ -3,6 +3,7 @@
 namespace FondOfSpryker\Zed\SalesRegionConnector\Business;
 
 use FondOfSpryker\Zed\SalesRegionConnector\Business\Expander\OrderAddressExpander;
+use FondOfSpryker\Zed\SalesRegionConnector\Business\Expander\OrderAddressExpanderInterface;
 use FondOfSpryker\Zed\SalesRegionConnector\Business\Model\SalesOrderAddressHydrator;
 use FondOfSpryker\Zed\SalesRegionConnector\Business\Model\SalesOrderAddressHydratorInterface;
 use FondOfSpryker\Zed\SalesRegionConnector\Dependency\Facade\SalesRegionConnectorToCountryFacadeInterface;
@@ -19,7 +20,10 @@ class SalesRegionConnectorBusinessFactory extends AbstractBusinessFactory
         return new SalesOrderAddressHydrator($this->getCountryFacade());
     }
 
-    public function createOrderAddressExpander()
+    /**
+     * @return \FondOfSpryker\Zed\SalesRegionConnector\Business\Expander\OrderAddressExpanderInterface
+     */
+    public function createOrderAddressExpander(): OrderAddressExpanderInterface
     {
         return new OrderAddressExpander($this->getCountryFacade());
     }

--- a/src/FondOfSpryker/Zed/SalesRegionConnector/Business/SalesRegionConnectorFacade.php
+++ b/src/FondOfSpryker/Zed/SalesRegionConnector/Business/SalesRegionConnectorFacade.php
@@ -30,4 +30,14 @@ class SalesRegionConnectorFacade extends AbstractFacade implements SalesRegionCo
             $salesOrderAddressEntity
         );
     }
+
+    /**
+     * @param \Generated\Shared\Transfer\AddressTransfer $addressTransfer
+     *
+     * @return \Generated\Shared\Transfer\AddressTransfer
+     */
+    public function expandOrderAddressWithRegion(AddressTransfer $addressTransfer): AddressTransfer
+    {
+        return $this->getFactory()->createOrderAddressExpander()->expandWithRegion($addressTransfer);
+    }
 }

--- a/src/FondOfSpryker/Zed/SalesRegionConnector/Business/SalesRegionConnectorFacadeInterface.php
+++ b/src/FondOfSpryker/Zed/SalesRegionConnector/Business/SalesRegionConnectorFacadeInterface.php
@@ -22,4 +22,16 @@ interface SalesRegionConnectorFacadeInterface
         AddressTransfer $addressTransfer,
         SpySalesOrderAddress $salesOrderAddressEntity
     ): SpySalesOrderAddress;
+
+    /**
+     * Specification:
+     * - Expand address transfer with region foreign key
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\AddressTransfer $addressTransfer
+     *
+     * @return \Generated\Shared\Transfer\AddressTransfer
+     */
+    public function expandOrderAddressWithRegion(AddressTransfer $addressTransfer): AddressTransfer;
 }

--- a/src/FondOfSpryker/Zed/SalesRegionConnector/Communication/Plugin/SalesExtension/RegionOrderAddressExpanderPlugin.php
+++ b/src/FondOfSpryker/Zed/SalesRegionConnector/Communication/Plugin/SalesExtension/RegionOrderAddressExpanderPlugin.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace FondOfSpryker\Zed\SalesRegionConnector\Communication\Plugin\SalesExtension;
+
+use FondOfSpryker\Zed\SalesExtension\Dependency\Plugin\OrderAddressExpanderPluginInterface;
+use Generated\Shared\Transfer\AddressTransfer;
+use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+
+/**
+ * @method \FondOfSpryker\Zed\SalesRegionConnector\Business\SalesRegionConnectorFacadeInterface getFacade()
+ */
+class RegionOrderAddressExpanderPlugin extends AbstractPlugin implements OrderAddressExpanderPluginInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\AddressTransfer $addressTransfer
+     *
+     * @return \Generated\Shared\Transfer\AddressTransfer
+     */
+    public function expand(AddressTransfer $addressTransfer): AddressTransfer
+    {
+        return $this->getFacade()->expandOrderAddressWithRegion($addressTransfer);
+    }
+}

--- a/tests/FondOfSpryker/Zed/SalesRegionConnector/Business/Expander/OrderAddressExpanderTest.php
+++ b/tests/FondOfSpryker/Zed/SalesRegionConnector/Business/Expander/OrderAddressExpanderTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace FondOfSpryker\Zed\SalesRegionConnector\Business\Expander;
+
+use Codeception\Test\Unit;
+use FondOfSpryker\Zed\SalesRegionConnector\Dependency\Facade\SalesRegionConnectorToCountryFacadeInterface;
+use Generated\Shared\Transfer\AddressTransfer;
+
+class OrderAddressExpanderTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfSpryker\Zed\SalesRegionConnector\Dependency\Facade\SalesRegionConnectorToCountryFacadeInterface
+     */
+    protected $countryFacadeMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\AddressTransfer
+     */
+    protected $addressTransferMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Orm\Zed\Sales\Persistence\SpySalesOrderAddress
+     */
+    protected $spySalesOrderAddressMock;
+
+    /**
+     * @var \FondOfSpryker\Zed\SalesRegionConnector\Business\Expander\OrderAddressExpander
+     */
+    protected $orderAddressExpander;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        $this->countryFacadeMock = $this->getMockBuilder(SalesRegionConnectorToCountryFacadeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->addressTransferMock = $this->getMockBuilder(AddressTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->orderAddressExpander = new OrderAddressExpander($this->countryFacadeMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpand(): void
+    {
+        $regionIso2Code = 'NW';
+        $fkRegion = 1;
+
+        $this->addressTransferMock->expects($this->atLeastOnce())
+            ->method('getRegion')
+            ->willReturn($regionIso2Code);
+
+        $this->addressTransferMock->expects($this->atLeastOnce())
+            ->method('getFkRegion')
+            ->willReturn(null);
+
+        $this->addressTransferMock->expects($this->atLeastOnce())
+            ->method('setFkRegion')
+            ->with($fkRegion)
+            ->willReturn($this->addressTransferMock);
+
+        $this->countryFacadeMock->expects($this->atLeastOnce())
+            ->method('getIdRegionByIso2Code')
+            ->with($regionIso2Code)
+            ->willReturn($fkRegion);
+
+        $addressTransfer = $this->orderAddressExpander->expandWithRegion(
+            $this->addressTransferMock
+        );
+
+        $this->assertEquals($this->addressTransferMock, $addressTransfer);
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpandWithAlreadyExistingFkRegion(): void
+    {
+        $regionIso2Code = 'NW';
+        $fkRegion = 1;
+
+        $this->addressTransferMock->expects($this->atLeastOnce())
+            ->method('getRegion')
+            ->willReturn($regionIso2Code);
+
+        $this->addressTransferMock->expects($this->atLeastOnce())
+            ->method('getFkRegion')
+            ->willReturn($fkRegion);
+
+        $this->countryFacadeMock->expects($this->never())
+            ->method('getIdRegionByIso2Code');
+
+        $this->addressTransferMock->expects($this->never())
+            ->method('setFkRegion');
+
+        $addressTransfer = $this->orderAddressExpander->expandWithRegion(
+            $this->addressTransferMock
+        );
+
+        $this->assertEquals($this->addressTransferMock, $addressTransfer);
+    }
+
+    /**
+     * @return void
+     */
+    public function testExpandWithoutExistingRegionIso2Code(): void
+    {
+        $regionIso2Code = null;
+
+        $this->addressTransferMock->expects($this->atLeastOnce())
+            ->method('getRegion')
+            ->willReturn($regionIso2Code);
+
+        $this->addressTransferMock->expects($this->never())
+            ->method('getFkRegion');
+
+        $this->countryFacadeMock->expects($this->never())
+            ->method('getIdRegionByIso2Code');
+
+        $this->addressTransferMock->expects($this->never())
+            ->method('setFkRegion');
+
+        $addressTransfer = $this->orderAddressExpander->expandWithRegion(
+            $this->addressTransferMock
+        );
+
+        $this->assertEquals($this->addressTransferMock, $addressTransfer);
+    }
+}


### PR DESCRIPTION
This plugin is used to solve a problem that the order address won't include the foreign key for the selected region. 
Therefor the region can't be used in order confirmation emails for example. 

The module extension is dependent on:

https://github.com/fond-of/spryker-sales/pull/4